### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/deploy_container.yaml
+++ b/.github/workflows/deploy_container.yaml
@@ -1,0 +1,40 @@
+name: Deploy Docker image
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMG_NAME: ${{ github.repository }}
+
+jobs:
+  docker_build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tags, labels for image
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMG_NAME }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y python3-dev python3-pip git build-essential
+
+ADD requirements.txt /opt/requirements.txt
+
+RUN pip install -r https://raw.githubusercontent.com/cmi-dair/niftyone/main/requirements.txt
+RUN pip install git+https://github.com/cmi-dair/niftyone.git
+
+EXPOSE 5151
+ENTRYPOINT ["niftyone"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
-FROM ubuntu:20.04
+ARG PY_VERSION=3.11
+FROM python:${PY_VERSION}-slim-bookworm as python
+RUN apt-get update -qq \
+    && apt-get install -y -q --no-install-recommends \
+    build-essential \
+    ffmpeg \
+    libcurl4 \
+    git \
+    openssl \
+    && python -m pip install --upgrade pip \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN apt-get update && apt-get install -y python3-dev python3-pip git build-essential
 
-ADD requirements.txt /opt/requirements.txt
+# NOTE: Set version to be able to checkout tag in future
+# (for now, installing latest from `main`)
+FROM python as builder
+ARG NIFTYONE_VER=0.0.0
+COPY . /opt/niftyone/
+RUN cd /opt/niftyone \
+    && pip wheel --no-deps --prefer-binary .
 
-RUN pip install -r https://raw.githubusercontent.com/cmi-dair/niftyone/main/requirements.txt
-RUN pip install git+https://github.com/cmi-dair/niftyone.git
-
+FROM builder as runtime
+WORKDIR /home
+ENV OS=LINUX
+RUN WHEEL=`ls /opt/niftyone | grep whl` \
+    && pip install /opt/niftyone/${WHEEL} \
+    && rm -r /opt/niftyone \
+    && apt-get --purge -y -qq autoremove
 EXPOSE 5151
 ENTRYPOINT ["niftyone"]


### PR DESCRIPTION
This PR builds on the existing branch started in this repo and addresses #13.

* Updates the Dockerfile to build a `niftyone` container using `python:3.11-slim-bookworm`. this still results in the container being around 5GB, with a lot of it I believe being `fiftyone` dependencies. Tested this with Docker + WSL and it works with some additional flags (which can be addressed in a separate PR updating documentation) - I'll include these in the notes below for now. 
* Adds a workflow to create and push to GH container registry upon new tag.

### Notes for using with Docker
* Mount `/.fiftyone` to a writable directory on the HOST machine
* Add `--network="host"` flags to be able to connect to application