### PR TITLE
Disable tracking

### DIFF
--- a/src/niftyone/analysis_levels/group.py
+++ b/src/niftyone/analysis_levels/group.py
@@ -17,6 +17,9 @@ from niclips.io import VideoWriter
 from niftyone.metadata.tags import TAGS
 from niftyone.typing import StrPath
 
+# Disable fiftyone tracking
+fo.config.do_not_track = True
+
 IMG_EXTENSIONS = {".png", ".mp4"}
 
 

--- a/src/niftyone/analysis_levels/launch.py
+++ b/src/niftyone/analysis_levels/launch.py
@@ -8,6 +8,9 @@ import fiftyone as fo
 from niftyone.metadata.tags import GroupTags
 from niftyone.typing import StrPath
 
+# Disable fiftyone tracking
+fo.config.do_not_track = True
+
 
 def launch(
     bids_dir: StrPath,

--- a/src/niftyone/metadata/tags.py
+++ b/src/niftyone/metadata/tags.py
@@ -9,6 +9,9 @@ from typing import Any
 import fiftyone as fo
 import pandas as pd
 
+# Disable fiftyone tracking
+fo.config.do_not_track = True
+
 TAGS = [
     "Fail",
     "Borderline",

--- a/tests/unit/niftyone/analysis_levels/test_launch.py
+++ b/tests/unit/niftyone/analysis_levels/test_launch.py
@@ -10,6 +10,9 @@ from _pytest.logging import LogCaptureFixture
 from niftyone.analysis_levels import launch
 from niftyone.metadata import tags
 
+# Disable fiftyone tracking
+fo.config.do_not_track = True
+
 
 @pytest.fixture
 def test_config(tmp_path: Path) -> dict[str, str | Path]:


### PR DESCRIPTION
Small PR to update the fiftyone config to disable tracking via the config. Currently this is set in a number of individual files where fiftyone is imported (for different analysis levels).