### PR TITLE
Add DWI figure generators

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup ffmpeg
+        uses: FedericoCarboni/setup-ffmpeg@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup python environment
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ tests/results
 *venv*
 
 # Jupyter
+notebooks/
 .ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ tests/results
 
 # Jupyter
 notebooks/
-.ipynb_checkpoints
+.ipynb_checkpoints/

--- a/src/niclips/figures/bold.py
+++ b/src/niclips/figures/bold.py
@@ -150,7 +150,7 @@ def carpet_plot(
     ax2.tick_params(colors="w", labelsize=8, direction="in", pad=-8)
 
     fig.set_facecolor("black")
-    if out is not None:
+    if out:
         fig.savefig(out, bbox_inches="tight", dpi=150)
     return fig
 
@@ -216,6 +216,6 @@ def bold_mean_std(
     grid = noimg.stack_images([panel_mean, panel_std], axis=0)
     grid_img = noimg.topil(grid)
 
-    if out is not None:
+    if out:
         grid_img.save(out)
     return grid_img

--- a/src/niclips/figures/bold.py
+++ b/src/niclips/figures/bold.py
@@ -2,7 +2,6 @@
 
 import math
 
-import matplotlib as mpl
 import matplotlib.figure as mpl_figure
 import nibabel as nib
 import numpy as np
@@ -20,7 +19,6 @@ from .multi_view import three_view_frame
 
 EPS = 1e-6
 plt.style.use("bmh")
-mpl.use("Agg")
 
 
 def cluster_timeseries(

--- a/src/niclips/figures/bold.py
+++ b/src/niclips/figures/bold.py
@@ -69,6 +69,7 @@ def carpet_plot(
     label_cmap: str = "brg",
     alpha: float = 0.3,
     figure: str | None = None,
+    **kwargs,
 ) -> mpl_figure.Figure:
     """BOLD "carpet" plot showing timeseries for a subset of voxels."""
     rng = np.random.default_rng(seed)
@@ -159,6 +160,7 @@ def bold_mean_std(
     *,
     std_vmax_ratio: float = 0.1,
     figure: str | None = None,
+    **kwargs,
 ) -> Image.Image:
     """Panel showing three-view BOLD mean and three-view tSNR."""
     check_4d(bold)

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -30,7 +30,7 @@ def _get_bval_indices(bvals: np.ndarray, bval: int) -> np.ndarray:
     return np.argwhere(bvals == bval)
 
 
-def visualize_shells(
+def visualize_qspace(
     dwi: Path,
     out: StrPath | None = None,
     *,
@@ -46,7 +46,7 @@ def visualize_shells(
     bvec_data = np.loadtxt(bvec)
 
     # Equivalent gradient magnitudes
-    bval_data = np.loadtxt(bval, dtype=int)
+    bval_data = np.loadtxt(bval).astype(int)
     bval_data = _equate_bvals(bval_data, thresh=thresh)
 
     # Generate animation

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -38,6 +38,7 @@ def visualize_qspace(
     out: StrPath | None = None,
     *,
     thresh: int = 10,
+    figure: str | None = None,
 ) -> FuncAnimation:
     """Visualize diffusion gradients in q-space."""
     # Grab paths and check existence

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -80,7 +80,7 @@ def visualize_qspace(
     ani = FuncAnimation(fig, _rotate, frames=np.arange(0, 360, 1), interval=30)
 
     if out:
-        ani.save(out, writer="ffmpeg", fps=30)
+        ani.save(out, writer="ffmpeg", fps=30, dpi=150)
     return ani
 
 

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -1,0 +1,80 @@
+"""Diffusion MRI figure generation module."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FuncAnimation
+
+from niclips.typing import StrPath
+
+
+def _equate_bvals(bvals: list[int], thresh: int) -> np.ndarray:
+    """Map bvals within a given threshold to each other."""
+    uniq_bvals = sorted(np.unique(bvals))
+    bval_map = {}
+
+    cur_bval = uniq_bvals[0]
+    idx = 0
+    for bval in uniq_bvals:
+        if (bval - cur_bval) > thresh:
+            cur_bval = bval
+            idx += 1
+        bval_map[bval] = idx
+
+    return np.array([bval_map[bval] for bval in bvals])
+
+
+def _get_bval_indices(bvals: np.ndarray, bval: int) -> np.ndarray:
+    """Grab indices corresponding to a given bval."""
+    return np.argwhere(bvals == bval)
+
+
+def visualize_shells(
+    dwi: Path,
+    out: StrPath | None = None,
+    *,
+    thresh: int = 10,
+) -> None:
+    """Visualize diffusion gradients in q-space."""
+    # Grab paths and check existence
+    bvec = dwi.with_suffix("").with_suffix(".bvec")
+    bval = dwi.with_suffix("").with_suffix(".bval")
+    assert all([bvec.exists(), bval.exists()])
+
+    # Gradient vector
+    bvec_data = np.loadtxt(bvec)
+
+    # Equivalent gradient magnitudes
+    bval_data = np.loadtxt(bval, dtype=int)
+    bval_data = _equate_bvals(bval_data, thresh=thresh)
+
+    # Generate animation
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+
+    # Plot by magnitude
+    for idx, val in enumerate(np.unique(bval_data)):
+        bval_idxes = _get_bval_indices(bval_data, val)
+        ax.scatter(
+            bvec_data[0, bval_idxes] * idx,
+            bvec_data[1, bval_idxes] * idx,
+            bvec_data[2, bval_idxes] * idx,
+            alpha=0.5,
+        )
+
+    # Settings
+    ax.set_title("Diffusion gradients in q-space")
+    ax.set_aspect("equal")
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
+    ax.set_zticklabels([])
+
+    # Animate
+    def _rotate(angle: int) -> None:
+        ax.view_init(elev=0, azim=angle, roll=0)
+
+    ani = FuncAnimation(fig, _rotate, frames=np.arange(0, 360, 1), interval=30)
+
+    if out:
+        ani.save(out, writer="ffmpeg", fps=30)

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -3,31 +3,34 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import nibabel as nib
 import numpy as np
 from matplotlib.animation import FuncAnimation
 
+import niclips.image as noimg
+from niclips.checks import check_4d
+from niclips.figures.multi_view import three_view_video
 from niclips.typing import StrPath
 
 
-def _equate_bvals(bvals: list[int], thresh: int) -> np.ndarray:
+def _equate_bvals(bvals: np.ndarray, thresh: int) -> np.ndarray:
     """Map bvals within a given threshold to each other."""
-    uniq_bvals = sorted(np.unique(bvals))
+    uniq_bvals = sorted(np.unique(bvals).astype(int))
     bval_map = {}
 
     cur_bval = uniq_bvals[0]
-    idx = 0
     for bval in uniq_bvals:
         if (bval - cur_bval) > thresh:
             cur_bval = bval
-            idx += 1
-        bval_map[bval] = idx
+        bval_map[bval] = cur_bval
 
     return np.array([bval_map[bval] for bval in bvals])
 
 
 def _get_bval_indices(bvals: np.ndarray, bval: int) -> np.ndarray:
     """Grab indices corresponding to a given bval."""
-    return np.argwhere(bvals == bval)
+    idxes = np.argwhere(bvals == bval)
+    return idxes[0] if len(idxes) == 1 else idxes
 
 
 def visualize_qspace(
@@ -35,7 +38,7 @@ def visualize_qspace(
     out: StrPath | None = None,
     *,
     thresh: int = 10,
-) -> None:
+) -> FuncAnimation:
     """Visualize diffusion gradients in q-space."""
     # Grab paths and check existence
     bvec = dwi.with_suffix("").with_suffix(".bvec")
@@ -78,3 +81,40 @@ def visualize_qspace(
 
     if out:
         ani.save(out, writer="ffmpeg", fps=30)
+    return ani
+
+
+def three_view_per_shell(
+    dwi: Path,
+    out: StrPath | None = None,
+    *,
+    thresh: int = 10,
+    replace_str: str = "bval",
+) -> list[nib.Nifti1Image]:
+    """Generate three-view videos per shell."""
+    # Grab bvals
+    bval = dwi.with_suffix("").with_suffix(".bval")
+    assert bval.exists()
+    bval_data = np.loadtxt(bval).astype(int)
+    bval_data = _equate_bvals(bval_data, thresh=thresh)
+
+    # Load image
+    dwi_data = nib.nifti1.load(dwi)
+    dwi_data = noimg.to_iso_ras(dwi_data)
+
+    figs = []
+    for val in np.unique(bval_data):
+        bval_idxes = _get_bval_indices(bval_data, val)
+        dwi_arr = dwi_data.dataobj[:, :, :, bval_idxes]
+        # Squeeze if necessary (e.g. more than 1 volume in a shell)
+        if len(dwi_arr.shape) == 5:
+            if dwi_arr.shape[-1] > 1:
+                raise ValueError(f"Diffusion image of the wrong shape {dwi_arr.shape}")
+            dwi_arr = np.squeeze(dwi_arr, axis=-1)
+        figs.append(nib.Nifti1Image(dwi_arr, affine=dwi_data.affine))
+        check_4d(figs[-1])
+
+        if out:
+            three_view_video(img=figs[-1], out=str(out).replace(replace_str, f"b{val}"))
+
+    return figs

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -48,7 +48,7 @@ def visualize_qspace(
     """Visualize diffusion gradients in q-space."""
     # Grab paths and check existence
     bvec = Path(re.sub(nii_pattern, ".bvec", dwi.get_filename()))
-    bval = Path(re.sub(nii_pattern, "bval", dwi.get_filename()))
+    bval = Path(re.sub(nii_pattern, ".bval", dwi.get_filename()))
     assert all([bvec.exists(), bval.exists()])
 
     # Gradient vector
@@ -99,7 +99,7 @@ def three_view_per_shell(
 ) -> list[nib.Nifti1Image]:
     """Generate three-view videos per shell."""
     # Grab bvals
-    bval = Path(re.sub(nii_pattern, "bval", dwi.get_filename()))
+    bval = Path(re.sub(nii_pattern, ".bval", dwi.get_filename()))
     assert bval.exists()
     bval_data = np.loadtxt(bval).astype(int)
     bval_data = _equate_bvals(bval_data, thresh=thresh)

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -1,5 +1,6 @@
 """Diffusion MRI figure generation module."""
 
+import re
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -13,6 +14,8 @@ from niclips.checks import check_4d
 from niclips.defaults import get_default_coord, get_default_vmin_vmax
 from niclips.figures.multi_view import three_view_video
 from niclips.typing import StrPath
+
+nii_pattern = r"(\.nii(\.gz)?)$"
 
 
 def _equate_bvals(bvals: np.ndarray, thresh: int) -> np.ndarray:
@@ -44,8 +47,8 @@ def visualize_qspace(
 ) -> FuncAnimation:
     """Visualize diffusion gradients in q-space."""
     # Grab paths and check existence
-    bvec = Path(dwi.get_filename().replace(".nii.gz", ".bvec"))
-    bval = Path(dwi.get_filename().replace(".nii.gz", ".bval"))
+    bvec = Path(re.sub(nii_pattern, ".bvec", dwi.get_filename()))
+    bval = Path(re.sub(nii_pattern, "bval", dwi.get_filename()))
     assert all([bvec.exists(), bval.exists()])
 
     # Gradient vector
@@ -96,7 +99,7 @@ def three_view_per_shell(
 ) -> list[nib.Nifti1Image]:
     """Generate three-view videos per shell."""
     # Grab bvals
-    bval = Path(dwi.get_filename().replace(".nii.gz", ".bval"))
+    bval = Path(re.sub(nii_pattern, "bval", dwi.get_filename()))
     assert bval.exists()
     bval_data = np.loadtxt(bval).astype(int)
     bval_data = _equate_bvals(bval_data, thresh=thresh)

--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
@@ -14,6 +15,7 @@ from niclips.defaults import get_default_coord, get_default_vmin_vmax
 from niclips.figures.multi_view import three_view_video
 from niclips.typing import StrPath
 
+mpl.use("Agg")
 
 def _equate_bvals(bvals: np.ndarray, thresh: int) -> np.ndarray:
     """Map bvals within a given threshold to each other."""

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -1,9 +1,11 @@
 """Generation of different multi-views."""
 
 from collections.abc import Sequence
+from pathlib import Path
 
 import nibabel as nib
 import numpy as np
+from bids2table import BIDSEntities
 from PIL import Image
 
 import niclips.image as noimg
@@ -73,6 +75,43 @@ def multi_view_frame(
     if out:
         grid_img.save(out)
     return grid_img
+
+
+def three_view_overlay_frame(
+    img: Path,
+    out: StrPath | None = None,
+    *,
+    entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
+) -> Image.Image:
+    """Construct overlay with image.
+
+    Default is to overlay with mask with similar entities
+    (e.g. entities = {"desc": "brain", "suffix": "mask"}).
+
+    For example:
+    'sub-01/anat/sub-01_ses-01_run-1_T1w.nii.gz' will be overlaid with
+    'sub-01/anat/sub-01_ses-01_run-1_desc-brain_mask.nii.gz'
+    """
+    # Grab mask based on provided entities
+    img_entities = BIDSEntities.from_path(img)
+    img_base_path = Path(str(img).replace(str(img_entities.to_path()), ""))
+    overlay_entities = img_entities.with_update(entities)
+    overlay = img_base_path.joinpath(overlay_entities.to_path())
+    assert overlay.exists()
+
+    # Load image
+    img_data = nib.nifti1.load(img)
+    img_data = noimg.to_iso_ras(img_data)
+    overlay_data = nib.nifti1.load(overlay)
+    overlay_data = noimg.to_iso_ras(overlay_data)
+
+    grid = three_view_frame(
+        img=img_data,
+        out=out,
+        overlay=overlay_data,
+    )
+
+    return grid
 
 
 def three_view_frame(

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -245,7 +245,7 @@ def slice_video_overlay(
     entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
     **kwargs,
 ) -> None:
-    """Construct three view video with overlay.
+    """Construct slice video with overlay.
 
     Default is to overlay with mask with similar entities
     (e.g. entities = {"desc": "brain", "suffix": "mask"}).

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -82,6 +82,7 @@ def three_view_overlay_frame(
     out: StrPath | None = None,
     *,
     entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
+    figure: str | None = None,
 ) -> Image.Image:
     """Construct overlay with image.
 

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -33,7 +33,7 @@ def multi_view_frame(
     """Construct a multi view image panel. Returns a PIL Image."""
     check_3d(img)
     check_iso_ras(img)
-    if overlay is not None:
+    if overlay:
         check_3d(overlay)
         check_iso_ras(overlay)
     vmin, vmax = get_default_vmin_vmax(img, vmin, vmax)
@@ -52,7 +52,7 @@ def multi_view_frame(
             fontsize=fontsize,
         )
 
-        if overlay is not None:
+        if overlay:
             panel_overlay = noimg.render_slice(
                 overlay,
                 axis=axis,
@@ -70,7 +70,7 @@ def multi_view_frame(
     grid = noimg.image_grid(panels_list, nrows=nrows)
     grid_img = noimg.topil(grid)
 
-    if out is not None:
+    if out:
         grid_img.save(out)
     return grid_img
 

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -1,11 +1,9 @@
 """Generation of different multi-views."""
 
 from collections.abc import Sequence
-from pathlib import Path
 
 import nibabel as nib
 import numpy as np
-from bids2table import BIDSEntities
 from PIL import Image
 
 import niclips.image as noimg
@@ -77,45 +75,6 @@ def multi_view_frame(
     return grid_img
 
 
-def three_view_overlay_frame(
-    img: Path,
-    out: StrPath | None = None,
-    *,
-    entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
-    **kwargs,
-) -> Image.Image:
-    """Construct overlay with image.
-
-    Default is to overlay with mask with similar entities
-    (e.g. entities = {"desc": "brain", "suffix": "mask"}).
-
-    For example:
-    'sub-01/anat/sub-01_ses-01_run-1_T1w.nii.gz' will be overlaid with
-    'sub-01/anat/sub-01_ses-01_run-1_desc-brain_mask.nii.gz'
-    """
-    # Grab mask based on provided entities
-    img_entities = BIDSEntities.from_path(img)
-    img_base_path = Path(str(img).replace(str(img_entities.to_path()), ""))
-    overlay_entities = img_entities.with_update(entities)
-    overlay = img_base_path.joinpath(overlay_entities.to_path())
-    assert overlay.exists()
-
-    # Load image
-    img_data = nib.nifti1.load(img)
-    img_data = noimg.to_iso_ras(img_data)
-    overlay_data = nib.nifti1.load(overlay)
-    overlay_data = noimg.to_iso_ras(overlay_data)
-
-    grid = three_view_frame(
-        img=img_data,
-        out=out,
-        overlay=overlay_data,
-        **kwargs,
-    )
-
-    return grid
-
-
 def three_view_frame(
     img: NiftiLike,
     out: StrPath | None = None,
@@ -162,43 +121,6 @@ def three_view_frame(
     return grid
 
 
-def three_view_overlay_video(
-    img: Path,
-    out: StrPath,
-    *,
-    entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
-    **kwargs,
-) -> None:
-    """Construct three view video with overlay.
-
-    Default is to overlay with mask with similar entities
-    (e.g. entities = {"desc": "brain", "suffix": "mask"}).
-
-    For example:
-    'sub-01/anat/sub-01_ses-01_run-1_T1w.nii.gz' will be overlaid with
-    'sub-01/anat/sub-01_ses-01_run-1_desc-brain_mask.nii.gz'
-    """
-    # Grab mask based on provided entities
-    img_entities = BIDSEntities.from_path(img)
-    img_base_path = Path(str(img).replace(str(img_entities.to_path()), ""))
-    overlay_entities = img_entities.with_update(entities)
-    overlay = img_base_path.joinpath(overlay_entities.to_path())
-    assert overlay.exists()
-
-    # Load image
-    img_data = nib.nifti1.load(img)
-    img_data = noimg.to_iso_ras(img_data)
-    overlay_data = nib.nifti1.load(overlay)
-    overlay_data = noimg.to_iso_ras(overlay_data)
-
-    three_view_video(
-        img=img_data,
-        out=out,
-        overlay=overlay_data,
-        **kwargs,
-    )
-
-
 def three_view_video(
     img: nib.Nifti1Image,
     out: StrPath,
@@ -236,43 +158,6 @@ def three_view_video(
                 frame, text=f"T={idx}", loc="upper right", size=fontsize
             )
             writer.put(frame)
-
-
-def slice_video_overlay(
-    img: Path,
-    out: StrPath,
-    *,
-    entities: dict[str, str] = {"desc": "brain", "suffix": "mask"},
-    **kwargs,
-) -> None:
-    """Construct slice video with overlay.
-
-    Default is to overlay with mask with similar entities
-    (e.g. entities = {"desc": "brain", "suffix": "mask"}).
-
-    For example:
-    'sub-01/anat/sub-01_ses-01_run-1_T1w.nii.gz' will be overlaid with
-    'sub-01/anat/sub-01_ses-01_run-1_desc-brain_mask.nii.gz'
-    """
-    # Grab mask based on provided entities
-    img_entities = BIDSEntities.from_path(img)
-    img_base_path = Path(str(img).replace(str(img_entities.to_path()), ""))
-    overlay_entities = img_entities.with_update(entities)
-    overlay = img_base_path.joinpath(overlay_entities.to_path())
-    assert overlay.exists()
-
-    # Load image
-    img_data = nib.nifti1.load(img)
-    img_data = noimg.to_iso_ras(img_data)
-    overlay_data = nib.nifti1.load(overlay)
-    overlay_data = noimg.to_iso_ras(overlay_data)
-
-    slice_video(
-        img=img_data,
-        out=out,
-        overlay=overlay_data,
-        **kwargs,
-    )
 
 
 def slice_video(

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -33,7 +33,7 @@ def multi_view_frame(
     """Construct a multi view image panel. Returns a PIL Image."""
     check_3d(img)
     check_iso_ras(img)
-    if overlay:
+    if overlay is not None:
         check_3d(overlay)
         check_iso_ras(overlay)
     vmin, vmax = get_default_vmin_vmax(img, vmin, vmax)
@@ -52,7 +52,7 @@ def multi_view_frame(
             fontsize=fontsize,
         )
 
-        if overlay:
+        if overlay is not None:
             panel_overlay = noimg.render_slice(
                 overlay,
                 axis=axis,
@@ -97,7 +97,7 @@ def three_view_frame(
         img = noimg.index_img(img, idx=idx)
     assert isinstance(img, nib.Nifti1Image)
 
-    if overlay and overlay.ndim == 4:
+    if overlay is not None and overlay.ndim == 4:
         overlay = noimg.index_img(overlay, idx=idx)
 
     if coord is None:
@@ -183,7 +183,7 @@ def slice_video(
     assert isinstance(img, nib.Nifti1Image)
     check_iso_ras(img)
 
-    if overlay and overlay.ndim == 4:
+    if overlay is not None and overlay.ndim == 4:
         overlay = noimg.index_img(overlay, idx=idx)
         check_iso_ras(overlay)
 
@@ -216,7 +216,7 @@ def slice_video(
                 fontsize=fontsize,
             )
 
-            if overlay:
+            if overlay is not None:
                 frame_overlay = noimg.render_slice(
                     overlay,
                     axis=axis,

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -89,7 +89,7 @@ def reorient(img: np.ndarray) -> np.ndarray:
 
 def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
     """Convert a nifti image to RAS orientation with isotropic resolution."""
-    img = reorder_img(img)
+    img = reorder_img(img, resample="nearest")
     affine = img.affine
     pixdim = np.diag(affine)[:3]
     if not np.all(pixdim == pixdim[0]):

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -75,9 +75,14 @@ def normalize(
 def scale(
     img: Image.Image, height: int, resample: Image.Resampling | None = None
 ) -> Image.Image:
-    """Scale an image to a target height."""
+    """Scale an image to a target height.
+
+    Ensure width is even numbered.
+    """
+    height += height % 2
     scale = height / img.height
-    size = int(scale * img.width), height
+    width = int(scale * img.width) + (int(scale * img.width) % 2)
+    size = width, height
     img = img.resize(size, resample=resample)
     return img
 

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -50,7 +50,7 @@ def overlay(
     img1 = img1.convert("RGBA")
     img2 = img2.convert("RGBA")
 
-    if alpha is not None:
+    if alpha:
         img2.putalpha(int(alpha * 255))
     img = Image.alpha_composite(img1, img2)
     return img

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -110,6 +110,6 @@ def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
                 img, target_affine=target_affine, interpolation="nearest"
             )
     # Set filepath to original incase it is needed
-    if img_path:
+    if img_path:  # pragma: no cover
         img.set_filename(img_path)
     return img

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -110,6 +110,6 @@ def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
                 img, target_affine=target_affine, interpolation="nearest"
             )
     # Set filepath to original incase it is needed
-    if img_path:  # pragma: no cover
+    if img_path:
         img.set_filename(img_path)
     return img

--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -94,6 +94,8 @@ def reorient(img: np.ndarray) -> np.ndarray:
 
 def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
     """Convert a nifti image to RAS orientation with isotropic resolution."""
+    # Grab original filepath
+    img_path = img.get_filename()
     img = reorder_img(img, resample="nearest")
     affine = img.affine
     pixdim = np.diag(affine)[:3]
@@ -107,4 +109,7 @@ def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
             img = resample_img(
                 img, target_affine=target_affine, interpolation="nearest"
             )
+    # Set filepath to original incase it is needed
+    if img_path:
+        img.set_filename(img_path)
     return img

--- a/src/niclips/io.py
+++ b/src/niclips/io.py
@@ -38,7 +38,7 @@ class VideoWriter:
         frame = av.VideoFrame.from_image(img)
         assert isinstance(self._stream, VideoStream)
         for packet in self._stream.encode(frame):
-            assert self._container is not None
+            assert self._container
             self._container.mux_one(packet)
 
     def init_stream(self, width: int, height: int) -> None:
@@ -52,7 +52,7 @@ class VideoWriter:
 
     def close(self) -> None:
         """Close the stream."""
-        if self._container is not None:
+        if self._container:
             # Flush stream
             assert isinstance(self._stream, VideoStream)
             for packet in self._stream.encode():

--- a/src/niclips/io.py
+++ b/src/niclips/io.py
@@ -37,7 +37,7 @@ class VideoWriter:
 
         frame = av.VideoFrame.from_image(img)
         assert isinstance(self._stream, VideoStream)
-        for packet in self._stream.encode(frame):  # pragma: no cover
+        for packet in self._stream.encode(frame):
             assert self._container
             self._container.mux_one(packet)
 

--- a/src/niclips/io.py
+++ b/src/niclips/io.py
@@ -37,7 +37,7 @@ class VideoWriter:
 
         frame = av.VideoFrame.from_image(img)
         assert isinstance(self._stream, VideoStream)
-        for packet in self._stream.encode(frame):
+        for packet in self._stream.encode(frame):  # pragma: no cover
             assert self._container
             self._container.mux_one(packet)
 

--- a/src/niclips/typing.py
+++ b/src/niclips/typing.py
@@ -1,6 +1,8 @@
 """Defined types used in niclips."""
 
 import os
+import typing
+from types import UnionType
 
 import nibabel as nib
 import numpy as np
@@ -10,3 +12,15 @@ StrPath = str | os.PathLike
 Coord = tuple[float, float, float] | np.ndarray
 
 NiftiLike = nib.nifti1.Nifti1Image | np.ndarray
+
+
+def get_union_subclass(
+    union_type: typing.Type[typing.Any], subclass: typing.Type[typing.Any]
+) -> bool:
+    """Function to check for union types."""
+    origin = typing.get_origin(union_type)
+    if origin is UnionType:
+        return any(
+            issubclass(union_cls, subclass) for union_cls in typing.get_args(union_type)
+        )
+    return issubclass(union_type, subclass)

--- a/src/niclips/typing.py
+++ b/src/niclips/typing.py
@@ -1,8 +1,6 @@
 """Defined types used in niclips."""
 
 import os
-import typing
-from types import UnionType
 
 import nibabel as nib
 import numpy as np
@@ -12,15 +10,3 @@ StrPath = str | os.PathLike
 Coord = tuple[float, float, float] | np.ndarray
 
 NiftiLike = nib.nifti1.Nifti1Image | np.ndarray
-
-
-def get_union_subclass(
-    union_type: typing.Type[typing.Any], subclass: typing.Type[typing.Any]
-) -> bool:
-    """Function to check for union types."""
-    origin = typing.get_origin(union_type)
-    if origin is UnionType:
-        return any(
-            issubclass(union_cls, subclass) for union_cls in typing.get_args(union_type)
-        )
-    return issubclass(union_type, subclass)

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -3,7 +3,11 @@
 from ._version import __version__, __version_tuple__
 
 # Register existing generators
-from .figures.dwi import DwiPerShellGenerator, QSpaceShellsGenerator
+from .figures.dwi import (
+    DwiPerShellGenerator,
+    QSpaceShellsGenerator,
+    SignalPerVolumeGenerator,
+)
 from .figures.func import CarpetPlotGenerator, MeanStdGenerator
 from .figures.multi_view import (
     SliceVideoGenerator,

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -7,6 +7,7 @@ from .figures.dwi import DwiPerShellGenerator, QSpaceShellsGenerator
 from .figures.func import CarpetPlotGenerator, MeanStdGenerator
 from .figures.multi_view import (
     SliceVideoGenerator,
+    SliceVideoOverlayGenerator,
     ThreeViewGenerator,
     ThreeViewOverlayGenerator,
     ThreeViewVideoGenerator,

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -3,10 +3,12 @@
 from ._version import __version__, __version_tuple__
 
 # Register existing generators
+from .figures.dwi import DwiPerShellGenerator, QSpaceShellsGenerator
 from .figures.func import CarpetPlotGenerator, MeanStdGenerator
 from .figures.multi_view import (
     SliceVideoGenerator,
     ThreeViewGenerator,
+    ThreeViewOverlayGenerator,
     ThreeViewVideoGenerator,
 )
 from .runner import Runner

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -11,10 +11,7 @@ from .figures.dwi import (
 from .figures.func import CarpetPlotGenerator, MeanStdGenerator
 from .figures.multi_view import (
     SliceVideoGenerator,
-    SliceVideoOverlayGenerator,
     ThreeViewGenerator,
-    ThreeViewOverlayGenerator,
     ThreeViewVideoGenerator,
-    ThreeViewVideoOverlayGenerator,
 )
 from .runner import Runner

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -15,5 +15,6 @@ from .figures.multi_view import (
     ThreeViewGenerator,
     ThreeViewOverlayGenerator,
     ThreeViewVideoGenerator,
+    ThreeViewVideoOverlayGenerator,
 )
 from .runner import Runner

--- a/src/niftyone/__main__.py
+++ b/src/niftyone/__main__.py
@@ -39,11 +39,15 @@ def main() -> None:
                 bids_dir=args.bids_dir,
                 out_dir=out_dir,
                 ds_name=args.ds_name,
+                qc_key=args.qc_key,
                 overwrite=args.overwrite,
             )
         case "launch":
             analysis_levels.launch(
-                bids_dir=args.bids_dir, out_dir=out_dir, qc_key=args.qc_key
+                bids_dir=args.bids_dir,
+                out_dir=out_dir,
+                ds_name=args.ds_name,
+                qc_key=args.qc_key,
             )
         case _:
             raise NotImplementedError(

--- a/src/niftyone/analysis_levels/group.py
+++ b/src/niftyone/analysis_levels/group.py
@@ -27,6 +27,7 @@ def group(
     bids_dir: StrPath,
     out_dir: StrPath,
     ds_name: str | None = None,
+    qc_key: str | None = None,
     overwrite: bool = False,
 ) -> None:
     """NiftyOne group analysis level.
@@ -39,12 +40,15 @@ def group(
     out_dir = Path(out_dir)
     if ds_name is None:
         ds_name = Path(bids_dir).name
+    if qc_key:
+        ds_name = f"{ds_name}-{qc_key}"
 
     logging.info(
         "Starting niftyone group-level:"
         f"\n\tdataset: {bids_dir}"
         f"\n\tout: {out_dir}"
         f"\n\tds_name: {ds_name}"
+        f"\n\tqc_key: {qc_key}"
         f"\n\toverwrite: {overwrite}"
     )
 

--- a/src/niftyone/analysis_levels/launch.py
+++ b/src/niftyone/analysis_levels/launch.py
@@ -51,9 +51,14 @@ def launch(
         tags.apply(dataset)
 
     session = fo.launch_app(dataset)
-    session.wait()
-
-    logging.info("Saving QC tags to %s", tags_path)
-    group_tags = GroupTags.from_dataset(dataset)
-    tags_path.parent.mkdir(exist_ok=True)
-    group_tags.to_json(tags_path)
+    try:
+        print("Press ctrl+c to exit...")
+        session.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        logging.info("Saving QC tags to %s", tags_path)
+        group_tags = GroupTags.from_dataset(dataset)
+        tags_path.parent.mkdir(exist_ok=True)
+        group_tags.to_json(tags_path)
+        session.close()

--- a/src/niftyone/analysis_levels/participant.py
+++ b/src/niftyone/analysis_levels/participant.py
@@ -8,6 +8,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Any
 
+import matplotlib as mpl
 import numpy as np
 import yaml  # type:ignore [import-untyped]
 from bids2table import BIDSTable, bids2table
@@ -140,6 +141,7 @@ def _participant_single(
     logging.info(f"Processing subject {sub}")
 
     runner.table = index.filter("sub", sub)
+    mpl.use("agg")
     runner.gen_figures()
     runner.update_metrics()
 

--- a/src/niftyone/cli.py
+++ b/src/niftyone/cli.py
@@ -1,6 +1,6 @@
 """CLI-related functions."""
 
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -12,19 +12,20 @@ class NiftyOneArgumentParser:
         self.parser = ArgumentParser(
             prog="niftyone",
             usage="%(prog)s bids_dir output_dir analysis_level [options]",
+            formatter_class=RawDescriptionHelpFormatter,
             description="""
-            NiftyOne is a comphrensive tool designed to aid
-            large-scale QC of BIDS datasets through visualization
-            and quantitative metrics.
+NiftyOne is a comphrensive tool designed to aid large-scale
+QC of BIDS datasets through visualization and quantitative
+metrics.
 
-
-            For details regarding each analysis level, see corresponding options.
-            """,
+The different analysis levels perform the following tasks:
+    * participant - generation of figures
+    * group - collects figures + qc metrics as NiftyOne samples
+    * launch - launches NiftyOne application""",
         )
         self._add_common_args()
         self._add_participant_args()
-        self._add_group_args()
-        self._add_launch_args()
+        self._add_group_launch_args()
 
     def _add_common_args(self) -> None:
         """Common (non-analysis specific) arguments."""
@@ -105,32 +106,24 @@ class NiftyOneArgumentParser:
             default=1,
         )
 
-    def _add_group_args(self) -> None:
-        """group-level CLI arguments."""
-        self.group_level = self.parser.add_argument_group(
-            title="Group level options",
-            description="Collects paths for samples (figures, metrics) for loading.",
+    def _add_group_launch_args(self) -> None:
+        """Application group / launch CLI arguments."""
+        self.launch_group = self.parser.add_argument_group(
+            title="group / launch level options",
         )
-        self.group_level.add_argument(
+        self.launch_group.add_argument(
             "--ds-name",
             metavar="DATASET",
             type=str,
             default=None,
-            help="name of NiftyOne dataset",
-        )
-
-    def _add_launch_args(self) -> None:
-        """Application launch CLI arguments."""
-        self.launch_group = self.parser.add_argument_group(
-            title="launch level options",
-            description="Launch NiftyOne application",
+            help="name of NiftyOne dataset (default: bids_dir)",
         )
         self.launch_group.add_argument(
             "--qc-key",
             metavar="LABEL",
             type=str,
             default=None,
-            help="extra identifier for the QC session",
+            help="extra identifier for the QC session (default: %(default)s)",
         )
 
     def parse_args(self, args: Sequence[str] | None = None) -> Namespace:

--- a/src/niftyone/cli.py
+++ b/src/niftyone/cli.py
@@ -16,6 +16,9 @@ class NiftyOneArgumentParser:
             NiftyOne is a comphrensive tool designed to aid
             large-scale QC of BIDS datasets through visualization
             and quantitative metrics.
+
+
+            For details regarding each analysis level, see corresponding options.
             """,
         )
         self._add_common_args()
@@ -42,7 +45,7 @@ class NiftyOneArgumentParser:
             metavar="analysis_level",
             type=str,
             choices=["participant", "group", "launch"],
-            help="analysis level",
+            help="analysis level - one of [%(choices)s]",
         )
         self.parser.add_argument(
             "--overwrite",
@@ -57,7 +60,8 @@ class NiftyOneArgumentParser:
     def _add_participant_args(self) -> None:
         """Participant-level CLI arguments."""
         self.participant_level = self.parser.add_argument_group(
-            "participant level options"
+            title="participant level options",
+            description="Generates figures for individual participants.",
         )
         self.participant_level.add_argument(
             "--participant-label",
@@ -103,7 +107,10 @@ class NiftyOneArgumentParser:
 
     def _add_group_args(self) -> None:
         """group-level CLI arguments."""
-        self.group_level = self.parser.add_argument_group("Group level options")
+        self.group_level = self.parser.add_argument_group(
+            title="Group level options",
+            description="Collects paths for samples (figures, metrics) for loading.",
+        )
         self.group_level.add_argument(
             "--ds-name",
             metavar="DATASET",
@@ -114,7 +121,10 @@ class NiftyOneArgumentParser:
 
     def _add_launch_args(self) -> None:
         """Application launch CLI arguments."""
-        self.launch_group = self.parser.add_argument_group("launch level options")
+        self.launch_group = self.parser.add_argument_group(
+            title="launch level options",
+            description="Launch NiftyOne application",
+        )
         self.launch_group.add_argument(
             "--qc-key",
             metavar="LABEL",

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -15,8 +15,7 @@ class QSpaceShellsGenerator(ViewGenerator):
             record=record,
             out_dir=out_dir,
             overwrite=overwrite,
-            desc="qspace",
-            ext=".mp4",
+            entities={"desc": "qspace", "ext": ".mp4"},
             view_fn=dwi.visualize_qspace,
         )
 
@@ -28,7 +27,6 @@ class DwiPerShellGenerator(ViewGenerator):
             record=record,
             out_dir=out_dir,
             overwrite=overwrite,
-            desc="bval",
-            ext=".mp4",
+            entities={"desc": "bval", "ext": ".mp4"},
             view_fn=dwi.three_view_per_shell,
         )

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -6,11 +6,11 @@ from niftyone.figures.generator import ViewGenerator, register
 
 @register("qspace_shells")
 class QSpaceShellsGenerator(ViewGenerator):
-    entities = {"desc": "qspace", "ext": ".mp4"}
+    entities = {"ext": ".mp4", "extra_entities": {"figure": "qspace"}}
     view_fn = staticmethod(dwi.visualize_qspace)
 
 
 @register("three_view_shell_video")
 class DwiPerShellGenerator(ViewGenerator):
-    entities = {"desc": "bval", "ext": ".mp4"}
+    entities = {"ext": ".mp4", "extra_entities": {"figure": "bval"}}
     view_fn = staticmethod(dwi.three_view_per_shell)

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -14,3 +14,9 @@ class QSpaceShellsGenerator(ViewGenerator):
 class DwiPerShellGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "bval"}}
     view_fn = staticmethod(dwi.three_view_per_shell)
+
+
+@register("signal_per_volume")
+class SignalPerVolumeGenerator(ViewGenerator):
+    entities = {"ext": ".mp4", "extra_entities": {"figure": "signalPerVolume"}}
+    view_fn = staticmethod(dwi.signal_per_volume)

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -1,32 +1,16 @@
 """Generators associated with diffusion data."""
 
-from pathlib import Path
-
-import pandas as pd
-
 from niclips.figures import dwi
 from niftyone.figures.generator import ViewGenerator, register
 
 
 @register("qspace_shells")
 class QSpaceShellsGenerator(ViewGenerator):
-    def generate(self, record: pd.Series, out_dir: Path, overwrite: bool) -> None:
-        self.generate_common(
-            record=record,
-            out_dir=out_dir,
-            overwrite=overwrite,
-            entities={"desc": "qspace", "ext": ".mp4"},
-            view_fn=dwi.visualize_qspace,
-        )
+    entities = {"desc": "qspace", "ext": ".mp4"}
+    view_fn = staticmethod(dwi.visualize_qspace)
 
 
 @register("three_view_shell_video")
 class DwiPerShellGenerator(ViewGenerator):
-    def generate(self, record: pd.Series, out_dir: Path, overwrite: bool) -> None:
-        self.generate_common(
-            record=record,
-            out_dir=out_dir,
-            overwrite=overwrite,
-            entities={"desc": "bval", "ext": ".mp4"},
-            view_fn=dwi.three_view_per_shell,
-        )
+    entities = {"desc": "bval", "ext": ".mp4"}
+    view_fn = staticmethod(dwi.three_view_per_shell)

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -19,3 +19,16 @@ class QSpaceShellsGenerator(ViewGenerator):
             ext=".mp4",
             view_fn=dwi.visualize_qspace,
         )
+
+
+@register("three_view_shell_video")
+class DwiPerShellGenerator(ViewGenerator):
+    def generate(self, record: pd.Series, out_dir: Path, overwrite: bool) -> None:
+        self.generate_common(
+            record=record,
+            out_dir=out_dir,
+            overwrite=overwrite,
+            desc="bval",
+            ext=".mp4",
+            view_fn=dwi.three_view_per_shell,
+        )

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -1,0 +1,21 @@
+"""Generators associated with diffusion data."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from niclips.figures import dwi
+from niftyone.figures.generator import ViewGenerator, register
+
+
+@register("qspace_shells")
+class QSpaceShellsGenerator(ViewGenerator):
+    def generate(self, record: pd.Series, out_dir: Path, overwrite: bool) -> None:
+        self.generate_common(
+            record=record,
+            out_dir=out_dir,
+            overwrite=overwrite,
+            desc="qspace",
+            ext=".mp4",
+            view_fn=dwi.visualize_shells,
+        )

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -17,5 +17,5 @@ class QSpaceShellsGenerator(ViewGenerator):
             overwrite=overwrite,
             desc="qspace",
             ext=".mp4",
-            view_fn=dwi.visualize_shells,
+            view_fn=dwi.visualize_qspace,
         )

--- a/src/niftyone/figures/func.py
+++ b/src/niftyone/figures/func.py
@@ -1,4 +1,4 @@
-"""Generators associated with multi-view."""
+"""Generators associated with functional data."""
 
 from niclips.figures import bold
 from niftyone.figures.generator import ViewGenerator, register

--- a/src/niftyone/figures/generator.py
+++ b/src/niftyone/figures/generator.py
@@ -15,6 +15,7 @@ from matplotlib.figure import Figure
 from PIL.Image import Image
 
 import niclips.image as noimg
+from niclips.typing import get_union_subclass
 
 T = TypeVar("T", bound="ViewGenerator")
 
@@ -121,7 +122,7 @@ class ViewGenerator(ABC, Generic[T]):
             list(signature.parameters.keys())[0]
         ].annotation
 
-        if issubclass(view_fn_input_type, Path):
+        if get_union_subclass(view_fn_input_type, Path):
             img = img_path
         else:
             img = nib.nifti1.load(img_path)

--- a/src/niftyone/figures/generator.py
+++ b/src/niftyone/figures/generator.py
@@ -116,7 +116,7 @@ class ViewGenerator(ABC, Generic[T]):
         img_path = Path(record["finfo"]["file_path"])
         logging.info("Processing: %s", img_path)
 
-        signature = inspect.signature(view_fn)
+        signature = inspect.signature(self.view_fn)
         view_fn_input_type = signature.parameters[
             list(signature.parameters.keys())[0]
         ].annotation

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -10,6 +10,12 @@ class ThreeViewGenerator(ViewGenerator):
     view_fn = staticmethod(multi_view.three_view_frame)
 
 
+@register("slice_video_overlay")
+class SliceVideoOverlayGenerator(ViewGenerator):
+    entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideoOverlay"}}
+    view_fn = staticmethod(multi_view.slice_video_overlay)
+
+
 @register("slice_video")
 class SliceVideoGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideo"}}
@@ -26,3 +32,9 @@ class ThreeViewOverlayGenerator(ViewGenerator):
 class ThreeViewVideoGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideo"}}
     view_fn = staticmethod(multi_view.three_view_video)
+
+
+@register("three_view_overlay_video")
+class ThreeViewVideoOverlayGenerator(ViewGenerator):
+    entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideoOverlay"}}
+    view_fn = staticmethod(multi_view.three_view_overlay_video)

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -18,7 +18,7 @@ class SliceVideoGenerator(ViewGenerator):
 
 @register("three_view_overlay")
 class ThreeViewOverlayGenerator(ViewGenerator):
-    entities = {"desc": "threeViewOverlay", "ext": ".png"}
+    entities = {"ext": ".png", "extra_entities": {"figure": "threeViewOverlay"}}
     view_fn = staticmethod(multi_view.three_view_overlay_frame)
 
 

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -16,6 +16,12 @@ class SliceVideoGenerator(ViewGenerator):
     view_fn = staticmethod(multi_view.slice_video)
 
 
+@register("three_view_overlay")
+class ThreeViewOverlayGenerator(ViewGenerator):
+    entities = {"desc": "threeViewOverlay", "ext": ".png"}
+    view_fn = staticmethod(multi_view.three_view_overlay_frame)
+
+
 @register("three_view_video")
 class ThreeViewVideoGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideo"}}

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -10,31 +10,13 @@ class ThreeViewGenerator(ViewGenerator):
     view_fn = staticmethod(multi_view.three_view_frame)
 
 
-@register("slice_video_overlay")
-class SliceVideoOverlayGenerator(ViewGenerator):
-    entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideoOverlay"}}
-    view_fn = staticmethod(multi_view.slice_video_overlay)
-
-
 @register("slice_video")
 class SliceVideoGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideo"}}
     view_fn = staticmethod(multi_view.slice_video)
 
 
-@register("three_view_overlay")
-class ThreeViewOverlayGenerator(ViewGenerator):
-    entities = {"ext": ".png", "extra_entities": {"figure": "threeViewOverlay"}}
-    view_fn = staticmethod(multi_view.three_view_overlay_frame)
-
-
 @register("three_view_video")
 class ThreeViewVideoGenerator(ViewGenerator):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideo"}}
     view_fn = staticmethod(multi_view.three_view_video)
-
-
-@register("three_view_overlay_video")
-class ThreeViewVideoOverlayGenerator(ViewGenerator):
-    entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideoOverlay"}}
-    view_fn = staticmethod(multi_view.three_view_overlay_video)

--- a/src/niftyone/resources/config.yaml
+++ b/src/niftyone/resources/config.yaml
@@ -2,6 +2,7 @@ anat:
   query: datatype == 'anat'
   views:
   - three_view(figure='anatThreeView')
+  - three_view_overlay
   - slice_video(axis=2)
 
 func:
@@ -13,7 +14,7 @@ func:
 
 dwi:
   query: datatype == 'dwi'
-  views: 
+  views:
   - qspace_shells(thresh=10)
   - three_view_video
   - three_view_shell_video

--- a/src/niftyone/resources/config.yaml
+++ b/src/niftyone/resources/config.yaml
@@ -1,5 +1,5 @@
 anat:
-  query: datatype == 'anat'
+  query: (datatype == 'anat' & suffix == 'T1w')
   views:
   - three_view(figure='anatThreeView')
   - three_view_overlay

--- a/src/niftyone/resources/config.yaml
+++ b/src/niftyone/resources/config.yaml
@@ -10,3 +10,10 @@ func:
   - three_view_video
   - carpet_plot
   - mean_std
+
+dwi:
+  query: datatype == 'dwi'
+  views: 
+  - qspace_shells(thresh=10)
+  - three_view_video
+  - three_view_shell_video

--- a/src/niftyone/resources/config.yaml
+++ b/src/niftyone/resources/config.yaml
@@ -1,20 +1,25 @@
-anat:
-  query: (datatype == 'anat' & suffix == 'T1w')
-  views:
-  - three_view(figure='anatThreeView')
-  - three_view_overlay
-  - slice_video(axis=2)
+# These queries are saved as YAML variables to be passed onto queries under the 'figures' key.
+# Alternatively, they can also be directly passed to the query key of each figure.
+# Note, this top-level 'queries' key is not directly interacted with in NiftyOne.
+queries:
+  t1w: &t1w datatype == 'anat' & suffix == 'T1w' & ext == '.nii.gz'
+  func: &func datatype == 'func' & ext == '.nii.gz'
 
-func:
-  query: datatype == 'func'
-  views:
-  - three_view_video
-  - carpet_plot
-  - mean_std
+# Below are the figures to be generated based on the provided queries, views
+# and view_kwargs. Multiple queries can be provided, with the first query
+# interpreted as the main image and all subsequent queries as the overlay.
+figures:
+  anat:
+    queries:
+    - *t1w
+    views:
+    - three_view(figure='anatThreeView')
+    - slice_video(axis=2)
 
-dwi:
-  query: datatype == 'dwi'
-  views:
-  - qspace_shells(thresh=10)
-  - three_view_video
-  - three_view_shell_video
+  func:
+    queries:
+    - *func
+    views:
+    - three_view_video
+    - carpet_plot
+    - mean_std

--- a/src/niftyone/resources/config.yaml
+++ b/src/niftyone/resources/config.yaml
@@ -13,13 +13,15 @@ figures:
     queries:
     - *t1w
     views:
-    - three_view(figure='anatThreeView')
-    - slice_video(axis=2)
+      three_view:
+        figure: anatThreeView
+      slice_video:
+        axis: 2
 
   func:
     queries:
     - *func
     views:
-    - three_view_video
-    - carpet_plot
-    - mean_std
+      three_view:
+      carpet_plot:
+      mean_std:

--- a/tests/unit/niclips/figures/test_dwi.py
+++ b/tests/unit/niclips/figures/test_dwi.py
@@ -114,3 +114,12 @@ class TestDwiPerShell:
 
         with pytest.raises(ValueError, match=".*wrong shape.*"):
             nodwi.three_view_per_shell(dwi=dwi_fpath, thresh=10)
+
+
+class TestDwiSignalPerVolume:
+    def test_default(self, nii_4d_img: nib.Nifti1Image, tmp_path: Path):
+        out_fpath = tmp_path / "test_desc-signalPerVolume_dwi.mp4"
+
+        nodwi.signal_per_volume(dwi=nii_4d_img, out=out_fpath)
+
+        assert out_fpath.exists()

--- a/tests/unit/niclips/figures/test_dwi.py
+++ b/tests/unit/niclips/figures/test_dwi.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from niclips.figures import dwi as nodwi
+
+
+@pytest.fixture
+def dwi_fpath(tmp_path: Path) -> Path:
+    bvals = np.array([5, 1600, 1600, 1600, 1595, 1600, 1605, 1595, 1600, 1595, 1595])
+    bval_fpath = tmp_path / "test.bval"
+    np.savetxt(bval_fpath, bvals)
+
+    bvecs = np.array(
+        [
+            [
+                0.57735026,
+                -0.9999969,
+                -0.586878,
+                -0.8942548,
+                -0.72977316,
+                0.15373544,
+                -0.11708178,
+                0.40867075,
+                -0.21039648,
+                -0.09445284,
+                0.13537486,
+            ],
+            [
+                0.57735032,
+                0.0,
+                0.71746105,
+                -0.44684735,
+                -0.54764342,
+                0.21455349,
+                0.62163621,
+                0.81375086,
+                -0.62104523,
+                -0.22652406,
+                0.99029183,
+            ],
+            [
+                -0.57735038,
+                0.00250311,
+                -0.37526515,
+                0.02521372,
+                -0.40928939,
+                0.96453744,
+                0.77450669,
+                -0.41327715,
+                0.75500739,
+                -0.96941489,
+                -0.03155597,
+            ],
+        ]
+    )
+    bvec_fpath = tmp_path / "test.bvec"
+    np.savetxt(bvec_fpath, bvecs)
+
+    return tmp_path / "test.nii.gz"
+
+
+class TestQSpaceShells:
+    @pytest.mark.parametrize("thresh", [(5), (10), (30)])
+    def test_default(self, dwi_fpath: Path, thresh: int):
+        nodwi.visualize_shells(dwi=dwi_fpath, thresh=thresh)
+
+    def test_save(self, dwi_fpath: Path, tmp_path: Path):
+        out_fpath = tmp_path / "test_qspace.mp4"
+        nodwi.visualize_shells(dwi=dwi_fpath, out=out_fpath)
+
+        assert out_fpath.exists()

--- a/tests/unit/niclips/figures/test_dwi.py
+++ b/tests/unit/niclips/figures/test_dwi.py
@@ -64,10 +64,10 @@ def dwi_fpath(tmp_path: Path) -> Path:
 class TestQSpaceShells:
     @pytest.mark.parametrize("thresh", [(5), (10), (30)])
     def test_default(self, dwi_fpath: Path, thresh: int):
-        nodwi.visualize_shells(dwi=dwi_fpath, thresh=thresh)
+        nodwi.visualize_qspace(dwi=dwi_fpath, thresh=thresh)
 
     def test_save(self, dwi_fpath: Path, tmp_path: Path):
         out_fpath = tmp_path / "test_qspace.mp4"
-        nodwi.visualize_shells(dwi=dwi_fpath, out=out_fpath)
+        nodwi.visualize_qspace(dwi=dwi_fpath, out=out_fpath)
 
         assert out_fpath.exists()

--- a/tests/unit/niclips/figures/test_multi_view.py
+++ b/tests/unit/niclips/figures/test_multi_view.py
@@ -95,7 +95,7 @@ class TestThreeViewOverlayFrame:
             .to_path(prefix=tmp_path)
         )
         overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, overlay_fpath)
+        nib.save(nii_4d_img, overlay_fpath)
         out_fpath = tmp_path / "test_overlay.png"
 
         grid = mv.three_view_overlay_frame(
@@ -112,6 +112,37 @@ class TestThreeViewVideo:
         assert out_fpath.exists()
 
 
+class TestThreeViewOverlayVideo:
+    @pytest.mark.parametrize(
+        "entities",
+        [
+            ({"desc": "brain", "suffix": "mask"}),
+            ({"datatype": "func", "run": 1, "suffix": "bold"}),
+        ],
+    )
+    def test_4d(
+        self,
+        nii_4d_img: nib.Nifti1Image,
+        nii_3d_img: nib.Nifti1Image,
+        tmp_path: Path,
+        entities: dict[str, str],
+    ):
+        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
+        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(nii_4d_img, nii_fpath)
+        overlay_fpath = (
+            BIDSEntities.from_path(nii_fpath)
+            .with_update(entities)
+            .to_path(prefix=tmp_path)
+        )
+        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(nii_3d_img, overlay_fpath)
+        out_fpath = tmp_path / "test_overlay_video.mp4"
+
+        mv.three_view_overlay_video(img=nii_fpath, out=out_fpath, entities=entities)
+        assert out_fpath.exists()
+
+
 class TestSliceVideo:
     def test_3d(self, nii_3d_img: nib.Nifti1Image, tmp_path: Path):
         out_fpath = tmp_path / "test_3d.mp4"
@@ -123,4 +154,59 @@ class TestSliceVideo:
         out_fpath = tmp_path / "test_4d.mp4"
         test_img = nib.Nifti1Image(np.random.rand(10, 10, 10, 3), affine=np.eye(4))
         mv.slice_video(img=test_img, out=out_fpath, idx=idx)
+        assert out_fpath.exists()
+
+
+class TestSliceVideoOverlay:
+    @pytest.mark.parametrize(
+        "entities",
+        [
+            ({"desc": "brain", "suffix": "mask"}),
+            ({"datatype": "func", "run": 1, "suffix": "bold"}),
+        ],
+    )
+    def test_3d(
+        self, nii_3d_img: nib.Nifti1Image, tmp_path: Path, entities: dict[str, str]
+    ):
+        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
+        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(nii_3d_img, nii_fpath)
+        overlay_fpath = (
+            BIDSEntities.from_path(nii_fpath)
+            .with_update(entities)
+            .to_path(prefix=tmp_path)
+        )
+        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(nii_3d_img, overlay_fpath)
+        out_fpath = tmp_path / "test_3d_overlay.mp4"
+
+        mv.slice_video_overlay(img=nii_fpath, out=out_fpath, entities=entities)
+        assert out_fpath.exists()
+
+    @pytest.mark.parametrize(
+        "entities",
+        [
+            ({"desc": "brain", "suffix": "mask"}),
+            ({"datatype": "func", "run": 1, "suffix": "bold"}),
+        ],
+    )
+    def test_4d(
+        self,
+        tmp_path: Path,
+        entities: dict[str, str],
+    ):
+        test_img = nib.Nifti1Image(np.random.rand(10, 10, 10, 3), affine=np.eye(4))
+        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
+        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(test_img, nii_fpath)
+        overlay_fpath = (
+            BIDSEntities.from_path(nii_fpath)
+            .with_update(entities)
+            .to_path(prefix=tmp_path)
+        )
+        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(test_img, overlay_fpath)
+        out_fpath = tmp_path / "test_4d_overlay.mp4"
+
+        mv.slice_video_overlay(img=nii_fpath, out=out_fpath, entities=entities)
         assert out_fpath.exists()

--- a/tests/unit/niclips/figures/test_multi_view.py
+++ b/tests/unit/niclips/figures/test_multi_view.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import nibabel as nib
 import numpy as np
 import pytest
-from bids2table import BIDSEntities
 from PIL import Image
 
 from niclips.figures import multi_view as mv
@@ -42,104 +41,15 @@ class TestThreeViewFrame:
         grid = mv.three_view_frame(img=nii_4d_img)
         assert isinstance(grid, Image.Image)
 
-
-class TestThreeViewOverlayFrame:
-    @pytest.mark.parametrize(
-        "entities",
-        [
-            ({"desc": "brain", "suffix": "mask"}),
-            ({"datatype": "func", "run": 1, "suffix": "bold"}),
-        ],
-    )
-    def test_3d(
-        self, nii_3d_img: nib.Nifti1Image, tmp_path: Path, entities: dict[str, str]
-    ):
-        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
-        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, nii_fpath)
-        overlay_fpath = (
-            BIDSEntities.from_path(nii_fpath)
-            .with_update(entities)
-            .to_path(prefix=tmp_path)
-        )
-        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, overlay_fpath)
-        out_fpath = tmp_path / "test_overlay.png"
-
-        grid = mv.three_view_overlay_frame(
-            img=nii_fpath, out=out_fpath, entities=entities
-        )
+    def test_overlay(self, nii_4d_img: nib.Nifti1Image):
+        grid = mv.three_view_frame(nii_4d_img, overlay=nii_4d_img)
         assert isinstance(grid, Image.Image)
-        assert out_fpath.exists()
-
-    @pytest.mark.parametrize(
-        "entities",
-        [
-            ({"desc": "brain", "suffix": "mask"}),
-            ({"datatype": "func", "run": 1, "suffix": "bold"}),
-        ],
-    )
-    def test_4d(
-        self,
-        nii_4d_img: nib.Nifti1Image,
-        nii_3d_img: nib.Nifti1Image,
-        tmp_path: Path,
-        entities: dict[str, str],
-    ):
-        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
-        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_4d_img, nii_fpath)
-        overlay_fpath = (
-            BIDSEntities.from_path(nii_fpath)
-            .with_update(entities)
-            .to_path(prefix=tmp_path)
-        )
-        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_4d_img, overlay_fpath)
-        out_fpath = tmp_path / "test_overlay.png"
-
-        grid = mv.three_view_overlay_frame(
-            img=nii_fpath, out=out_fpath, entities=entities
-        )
-        assert isinstance(grid, Image.Image)
-        assert out_fpath.exists()
 
 
 class TestThreeViewVideo:
     def test_default(self, nii_4d_img: nib.Nifti1Image, tmp_path: Path):
         out_fpath = tmp_path / "test_three_view.mp4"
         mv.three_view_video(nii_4d_img, out=out_fpath)
-        assert out_fpath.exists()
-
-
-class TestThreeViewOverlayVideo:
-    @pytest.mark.parametrize(
-        "entities",
-        [
-            ({"desc": "brain", "suffix": "mask"}),
-            ({"datatype": "func", "run": 1, "suffix": "bold"}),
-        ],
-    )
-    def test_4d(
-        self,
-        nii_4d_img: nib.Nifti1Image,
-        nii_3d_img: nib.Nifti1Image,
-        tmp_path: Path,
-        entities: dict[str, str],
-    ):
-        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
-        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_4d_img, nii_fpath)
-        overlay_fpath = (
-            BIDSEntities.from_path(nii_fpath)
-            .with_update(entities)
-            .to_path(prefix=tmp_path)
-        )
-        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, overlay_fpath)
-        out_fpath = tmp_path / "test_overlay_video.mp4"
-
-        mv.three_view_overlay_video(img=nii_fpath, out=out_fpath, entities=entities)
         assert out_fpath.exists()
 
 
@@ -156,57 +66,8 @@ class TestSliceVideo:
         mv.slice_video(img=test_img, out=out_fpath, idx=idx)
         assert out_fpath.exists()
 
-
-class TestSliceVideoOverlay:
-    @pytest.mark.parametrize(
-        "entities",
-        [
-            ({"desc": "brain", "suffix": "mask"}),
-            ({"datatype": "func", "run": 1, "suffix": "bold"}),
-        ],
-    )
-    def test_3d(
-        self, nii_3d_img: nib.Nifti1Image, tmp_path: Path, entities: dict[str, str]
-    ):
-        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
-        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, nii_fpath)
-        overlay_fpath = (
-            BIDSEntities.from_path(nii_fpath)
-            .with_update(entities)
-            .to_path(prefix=tmp_path)
-        )
-        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nii_3d_img, overlay_fpath)
-        out_fpath = tmp_path / "test_3d_overlay.mp4"
-
-        mv.slice_video_overlay(img=nii_fpath, out=out_fpath, entities=entities)
-        assert out_fpath.exists()
-
-    @pytest.mark.parametrize(
-        "entities",
-        [
-            ({"desc": "brain", "suffix": "mask"}),
-            ({"datatype": "func", "run": 1, "suffix": "bold"}),
-        ],
-    )
-    def test_4d(
-        self,
-        tmp_path: Path,
-        entities: dict[str, str],
-    ):
+    def test_overlay(self, tmp_path: Path):
+        out_fpath = tmp_path / "test_overlay.mp4"
         test_img = nib.Nifti1Image(np.random.rand(10, 10, 10, 3), affine=np.eye(4))
-        nii_fpath = tmp_path.joinpath("sub-test/anat/sub-test_img.nii.gz")
-        nii_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(test_img, nii_fpath)
-        overlay_fpath = (
-            BIDSEntities.from_path(nii_fpath)
-            .with_update(entities)
-            .to_path(prefix=tmp_path)
-        )
-        overlay_fpath.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(test_img, overlay_fpath)
-        out_fpath = tmp_path / "test_4d_overlay.mp4"
-
-        mv.slice_video_overlay(img=nii_fpath, out=out_fpath, entities=entities)
+        mv.slice_video(img=test_img, out=out_fpath, overlay=test_img)
         assert out_fpath.exists()

--- a/tests/unit/niclips/test_io.py
+++ b/tests/unit/niclips/test_io.py
@@ -33,14 +33,14 @@ class TestVideoWriterPut:
     def test_put_array(self, img_array: np.ndarray, video_writer: noio.VideoWriter):
         video_writer.put(img_array)
 
-        assert video_writer._container is not None
-        assert video_writer._stream is not None
+        assert video_writer._container
+        assert video_writer._stream
 
     def test_put_pil_img(self, img_pil: Image.Image, video_writer: noio.VideoWriter):
         video_writer.put(img_pil)
 
-        assert video_writer._container is not None
-        assert video_writer._stream is not None
+        assert video_writer._container
+        assert video_writer._stream
 
 
 class TestVideoWriterInitFunc:
@@ -48,8 +48,8 @@ class TestVideoWriterInitFunc:
         width, height = 100, 100
         video_writer.init_stream(width=width, height=height)
 
-        assert video_writer._container is not None
-        assert video_writer._stream is not None
+        assert video_writer._container
+        assert video_writer._stream
         assert video_writer._stream.width == width
         assert video_writer._stream.height == height
 
@@ -64,5 +64,5 @@ def used_video_writer(video_writer: noio.VideoWriter) -> noio.VideoWriter:
 class TestVideoWriterClose:
     def test_flush_and_close(self, used_video_writer: noio.VideoWriter):
         used_video_writer.close()
-        assert used_video_writer._container is not None
+        assert used_video_writer._container
         used_video_writer._container.close.assert_called()

--- a/tests/unit/niftyone/figures/test_generator.py
+++ b/tests/unit/niftyone/figures/test_generator.py
@@ -20,13 +20,7 @@ from niftyone.figures.generator import (
 def b2t_mock():
     table_mock = MagicMock(spec=BIDSTable)
     table_mock.ent.query.side_effect = [
-        pd.DataFrame(
-            {
-                "finfo": [{"file_path": "path1.nii"}],
-                "ent": [{"sub": "01", "suffix": "T1w"}],
-            },
-            index=[0],
-        )
+        pd.DataFrame({"sub": "01", "ses": "01", "suffix": "T1w"}, index=[0])
     ]
 
     return table_mock


### PR DESCRIPTION
_Moved over from https://github.com/kaitj/niftyone/pull/2 now that the figure factor has been merged in._

Adds DWI figure generators to the workflow. The main functionality is there, however, after some discussion, we would like to refactor how the configuration file is handled / querying of the `BIDSTable`. This branch can still be used to generate figures as a "dev" version, but will hold off on marking it as ready for review until refactor is complete (notes below may change).

Notes:
* Generating diffusion gradients in q-space (useful for a quick QC of raw dwi data to check acquisition). To avoid filtering for additional extensions (.bval, .bvec), the original nifti filepath is saved to the resampled nifti object. This filepath can then be called with the extension replaced.
* Added `ffmpeg` to github actions, which is a requirement anyways for niftyone videos, but was causing issues with saving using `matplotlib.animation.FuncAnimation`.
* Added rescaling on image reordering when calling `to_iso_ras`, which is needed when affine contains rotations.
* Ensured image is generated with even-numbered dimensions (via `scale`), otherwise video codec throws an error when trying to create video.
* Overhaul config + figure generators to handle multiple queries and joining them via `join_entities`. At the moment, the figure generators can only handle 1 overlay at a time, but this can be fixed in a future PR to handle multiple overlays. Some temporary logic has been put in place of the generate function to ensure that only a single overlay is provided.
* Combined group / launch level arguments - these should always be the same anyways since it ultimately sets the dataset name. I've also added the qc-key argument to the group level. If we need group-level specific arguments in the future, we can add a new group of it.