### PR TITLE
Add MongoDB to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ ARG FO_VERSION=0.25.0
 ARG PY_VERSION=python3.11
 FROM voxel51/fiftyone:${FO_VERSION}-${PY_VERSION} AS builder
 
-# NOTE: Set version to be able to checkout tag in future
-# (for now, installing latest from `main`)
+# Will install version currently checked out
 FROM builder AS niftyone
-ARG NO_VERSION=0.0.0
 COPY . /opt/niftyone/
 RUN apt-get update -qq \
     && apt-get install -y git \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 av==12.3.0
 bids2table==0.1.0
 elbow==0.1.1
-fiftyone==0.24.1
+fiftyone==0.25.0
 matplotlib==3.9.1
 nibabel==5.2.1
 nilearn==0.10.4


### PR DESCRIPTION
Resolves #23 and follows up on #21. Good for a look but would hold off merging until #21 is merged in. This adds MongoDB to the container such that it can be used as a standalone without additional dependencies to be installed. Also sets the database directory to `/home/.fiftyone` (which is default) to ensure that it can be written to without having to set additional permissions.

_(Actually, as I am writing up this PR, I think fiftyone may already automatically installs mongo if it can't be found, but I guess this will explicitly install it)._