### PR TITLE
Multi-image overlay

### DIFF
--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -161,8 +161,6 @@ def signal_per_volume(
     (dot,) = ax2.plot([], [], "ro")
     ax2.set_xlim(0, signal.shape[-1] + 1)
     ax2.set_ylim(0, np.max(signal) + 1)
-    # aspect = w / h / 2
-    # ax2.set_aspect(aspect)
     ax2.set_xlabel("Volume")
     ax2.set_ylabel("Signal")
 

--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -1,9 +1,11 @@
 """Generation of different multi-views."""
 
 from collections.abc import Sequence
+from itertools import zip_longest
 
 import nibabel as nib
 import numpy as np
+from matplotlib.pyplot import cm
 from PIL import Image
 
 import niclips.image as noimg
@@ -21,11 +23,11 @@ def multi_view_frame(
     axes: list[int],
     vmin: float | None = None,
     vmax: float | None = None,
-    overlay: nib.Nifti1Image | None = None,
+    overlay: list[nib.Nifti1Image] = [],
     nrows: int = 1,
     panel_height: int | None = 256,
     cmap: str = "gray",
-    overlay_cmap: str = "turbo",
+    overlay_cmap: list[str] = [],
     alpha: float = 0.5,
     fontsize: int = 14,
     figure: str | None = None,
@@ -33,13 +35,14 @@ def multi_view_frame(
     """Construct a multi view image panel. Returns a PIL Image."""
     check_3d(img)
     check_iso_ras(img)
-    if overlay is not None:
-        check_3d(overlay)
-        check_iso_ras(overlay)
+    if len(overlay) > 0:
+        for ov in overlay:
+            check_3d(ov)
+            check_iso_ras(ov)
     vmin, vmax = get_default_vmin_vmax(img, vmin, vmax)
 
     panels: list[Image.Image] = []
-    for coord, axis in zip(coords, axes):
+    for coord, axis in zip_longest(coords, axes):
         panel = noimg.render_slice(
             img,
             axis=axis,
@@ -52,16 +55,18 @@ def multi_view_frame(
             fontsize=fontsize,
         )
 
-        if overlay is not None:
-            panel_overlay = noimg.render_slice(
-                overlay,
-                axis=axis,
-                coord=coord,
-                height=panel_height,
-                cmap=overlay_cmap,
-                fontsize=fontsize,
-            )
-            panel = noimg.overlay(panel, panel_overlay, alpha=alpha)
+        if len(overlay) > 0:
+            colors = iter(cm.turbo(np.linspace(0, 1, len(overlay))))
+            for ov, ov_cmap in zip(overlay, overlay_cmap):
+                panel_overlay = noimg.render_slice(
+                    ov,
+                    axis=axis,
+                    coord=coord,
+                    height=panel_height,
+                    cmap=ov_cmap or next(colors),
+                    fontsize=fontsize,
+                )
+                panel = noimg.overlay(panel, panel_overlay, alpha - alpha)
 
         panels.append(panel)
 
@@ -83,10 +88,10 @@ def three_view_frame(
     idx: int | None = 0,
     vmin: float | None = None,
     vmax: float | None = None,
-    overlay: nib.Nifti1Image | None = None,
+    overlay: list[nib.Nifti1Image] = [],
     panel_height: int | None = 256,
     cmap: str = "gray",
-    overlay_cmap: str = "turbo",
+    overlay_cmap: list[str] = [],
     alpha: float = 0.5,
     fontsize: int = 14,
     figure: str | None = None,
@@ -97,8 +102,11 @@ def three_view_frame(
         img = noimg.index_img(img, idx=idx)
     assert isinstance(img, nib.Nifti1Image)
 
-    if overlay is not None and overlay.ndim == 4:
-        overlay = noimg.index_img(overlay, idx=idx)
+    if len(overlay) > 0:
+        print("Are we in here?")
+        for idx, ov in enumerate(overlay):
+            if ov.ndim == 4:
+                overlay[idx] = noimg.index_img(ov, idx=idx)
 
     if coord is None:
         coord = get_default_coord(img)
@@ -128,7 +136,7 @@ def three_view_video(
     coord: tuple[float, float, float] | None = None,
     vmin: float | None = None,
     vmax: float | None = None,
-    overlay: nib.Nifti1Image | None = None,
+    overlay: list[nib.Nifti1Image] = [],
     panel_height: int | None = 256,
     cmap: str = "gray",
     fontsize: int = 14,
@@ -168,7 +176,7 @@ def slice_video(
     idx: int | None = 0,
     vmin: float | None = None,
     vmax: float | None = None,
-    overlay: nib.Nifti1Image | None = None,
+    overlay: list[nib.Nifti1Image] = [],
     panel_height: int | None = 256,
     cmap: str = "gray",
     overlay_cmap: str = "brg",
@@ -183,9 +191,12 @@ def slice_video(
     assert isinstance(img, nib.Nifti1Image)
     check_iso_ras(img)
 
-    if overlay is not None and overlay.ndim == 4:
-        overlay = noimg.index_img(overlay, idx=idx)
-        check_iso_ras(overlay)
+    if len(overlay) > 0:
+        for idx, ov in enumerate(overlay):
+            if ov.ndim == 4:
+                ov = noimg.index_img(ov, idx=idx)
+                check_iso_ras(ov)
+                overlay[idx] = ov
 
     vmin, vmax = get_default_vmin_vmax(img, vmin, vmax)
 
@@ -216,14 +227,15 @@ def slice_video(
                 fontsize=fontsize,
             )
 
-            if overlay is not None:
-                frame_overlay = noimg.render_slice(
-                    overlay,
-                    axis=axis,
-                    coord=coord,
-                    cmap=overlay_cmap,
-                    fontsize=fontsize,
-                )
-                frame = noimg.overlay(frame, frame_overlay, alpha=alpha)
+            if len(overlay) > 0:
+                for ov in overlay:
+                    frame_overlay = noimg.render_slice(
+                        ov,
+                        axis=axis,
+                        coord=coord,
+                        cmap=overlay_cmap,
+                        fontsize=fontsize,
+                    )
+                    frame = noimg.overlay(frame, frame_overlay, alpha=alpha)
 
             writer.put(frame)

--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -4,14 +4,14 @@ from ._version import __version__, __version_tuple__
 
 # Register existing views
 from .figures.dwi import (
-    DwiPerShellGenerator,
-    QSpaceShellsGenerator,
-    SignalPerVolumeGenerator,
+    DwiPerShell,
+    QSpaceShells,
+    SignalPerVolume,
 )
-from .figures.func import CarpetPlotGenerator, MeanStdGenerator
+from .figures.func import CarpetPlot, MeanStd
 from .figures.multi_view import (
-    SliceVideoGenerator,
-    ThreeViewGenerator,
-    ThreeViewVideoGenerator,
+    SliceVideo,
+    ThreeView,
+    ThreeViewVideo,
 )
 from .runner import Runner

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -1,22 +1,22 @@
-"""Generators associated with diffusion data."""
+"""Factories associated with diffusion data."""
 
 from niclips.figures import dwi
 from niftyone.figures.factory import View, register
 
 
 @register("qspace_shells")
-class QSpaceShellsGenerator(View):
+class QSpaceShells(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "qspace"}}
     view_fn = staticmethod(dwi.visualize_qspace)
 
 
 @register("three_view_shell_video")
-class DwiPerShellGenerator(View):
+class DwiPerShell(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "bval"}}
     view_fn = staticmethod(dwi.three_view_per_shell)
 
 
 @register("signal_per_volume")
-class SignalPerVolumeGenerator(View):
+class SignalPerVolume(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "signalPerVolume"}}
     view_fn = staticmethod(dwi.signal_per_volume)

--- a/src/niftyone/figures/factory.py
+++ b/src/niftyone/figures/factory.py
@@ -146,9 +146,6 @@ class View(ABC, Generic[T]):
 
         # Handle overlays - currently only handles 1, update to handle multiple
         if len(records) > 1:
-            # Temporary logic to handle multiple overlays
-            if len(records) > 2:
-                raise NotImplementedError("Multi-image overlay not yet implemented")
             overlays: list[nib.Nifti1Image] = []
             for overlay_record in records[1:]:
                 overlay_path = Path(overlay_record["finfo"]["file_path"])

--- a/src/niftyone/figures/func.py
+++ b/src/niftyone/figures/func.py
@@ -1,16 +1,16 @@
-"""Generators associated with functional data."""
+"""Factories associated with functional data."""
 
 from niclips.figures import bold
 from niftyone.figures.factory import View, register
 
 
 @register("carpet_plot")
-class CarpetPlotGenerator(View):
+class CarpetPlot(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "carpet"}}
     view_fn = staticmethod(bold.carpet_plot)
 
 
 @register("mean_std")
-class MeanStdGenerator(View):
+class MeanStd(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "meanStd"}}
     view_fn = staticmethod(bold.bold_mean_std)

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -1,22 +1,22 @@
-"""Generators associated with multi-view."""
+"""Factories associated with multi-view."""
 
 from niclips.figures import multi_view
 from niftyone.figures.factory import View, register
 
 
 @register("three_view")
-class ThreeViewGenerator(View):
+class ThreeView(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "threeView"}}
     view_fn = staticmethod(multi_view.three_view_frame)
 
 
 @register("slice_video")
-class SliceVideoGenerator(View):
+class SliceVideo(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideo"}}
     view_fn = staticmethod(multi_view.slice_video)
 
 
 @register("three_view_video")
-class ThreeViewVideoGenerator(View):
+class ThreeViewVideo(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideo"}}
     view_fn = staticmethod(multi_view.three_view_video)

--- a/tests/unit/niclips/figures/test_multi_view.py
+++ b/tests/unit/niclips/figures/test_multi_view.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import nibabel as nib
 import numpy as np
 import pytest
+from _pytest.logging import LogCaptureFixture
 from PIL import Image
 
 from niclips.figures import multi_view as mv
@@ -24,6 +25,28 @@ class TestMultiViewFrame:
             overlay=[nii_3d_img, nii_3d_img],
         )
         assert isinstance(frame, Image.Image)
+
+    def test_overlay_cmap(self, nii_3d_img: nib.Nifti1Image):
+        frame = mv.multi_view_frame(
+            img=nii_3d_img,
+            coords=[(0, 0, 0)],
+            axes=[0],
+            overlay=[nii_3d_img, nii_3d_img],
+            overlay_cmap=["brg", "turbo"],
+        )
+        assert isinstance(frame, Image.Image)
+
+    def test_overlay_cmap_warning(
+        self, nii_3d_img: nib.Nifti1Image, caplog: LogCaptureFixture
+    ):
+        mv.multi_view_frame(
+            img=nii_3d_img,
+            coords=[(0, 0, 0)],
+            axes=[0],
+            overlay=[nii_3d_img, nii_3d_img],
+            overlay_cmap=["brg"],
+        )
+        assert "More overlays" in caplog.text
 
     def test_save_frame(self, nii_3d_img: nib.Nifti1Image, tmp_path: Path):
         out_path = tmp_path / "test.png"

--- a/tests/unit/niclips/figures/test_multi_view.py
+++ b/tests/unit/niclips/figures/test_multi_view.py
@@ -21,7 +21,7 @@ class TestMultiViewFrame:
             img=nii_3d_img,
             coords=[(0, 0, 0)],
             axes=[0],
-            overlay=nii_3d_img,
+            overlay=[nii_3d_img, nii_3d_img],
         )
         assert isinstance(frame, Image.Image)
 
@@ -42,7 +42,7 @@ class TestThreeViewFrame:
         assert isinstance(grid, Image.Image)
 
     def test_overlay(self, nii_4d_img: nib.Nifti1Image):
-        grid = mv.three_view_frame(nii_4d_img, overlay=nii_4d_img)
+        grid = mv.three_view_frame(nii_4d_img, overlay=[nii_4d_img, nii_4d_img])
         assert isinstance(grid, Image.Image)
 
 
@@ -69,5 +69,5 @@ class TestSliceVideo:
     def test_overlay(self, tmp_path: Path):
         out_fpath = tmp_path / "test_overlay.mp4"
         test_img = nib.Nifti1Image(np.random.rand(10, 10, 10, 3), affine=np.eye(4))
-        mv.slice_video(img=test_img, out=out_fpath, overlay=test_img)
+        mv.slice_video(img=test_img, out=out_fpath, overlay=[test_img])
         assert out_fpath.exists()


### PR DESCRIPTION
Minor one here, following up on #21 - enables multi-image overlay capabilities. 

* Removes the 2 record limit prevoiusly placed on main image + overlay
* Switches overlays and overlay colormaps from single input to a list of inputs, looping over them to generate the frame as needed. If more overlays than color maps provided, it just defaults to the same color map (alternatively, we could raise an exception?)