### PR TITLE
Fix niclips.to_iso_ras

### DIFF
--- a/src/niclips/image/_convert.py
+++ b/src/niclips/image/_convert.py
@@ -107,7 +107,10 @@ def to_iso_ras(img: nib.nifti1.Nifti1Image) -> nib.nifti1.Nifti1Image:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             img = resample_img(
-                img, target_affine=target_affine, interpolation="nearest"
+                img,
+                target_affine=target_affine,
+                target_shape=img.header.get_data_shape(),
+                interpolation="nearest",
             )
     # Set filepath to original incase it is needed
     if img_path:


### PR DESCRIPTION
The resampling that is performed in `niclips.image.to_iso_ras`, is sometimes causing the image shape to be changed (e.g. one dimension goes from `150` to `151` in one image, but not another). This adds the `target_shape` argument to the `resample` command to ensure the image retains the original shape after the `iso_ras` resampling.

Not an issue on single image figures, but potentially problematic when also including overlays (which currently require volumes to have the same shape). Wouldn't alter how overlays are handled currently.