### PR TITLE
Replace variations of 'generate' to avoid confusion with Python generators

### DIFF
--- a/src/niftyone/__init__.py
+++ b/src/niftyone/__init__.py
@@ -2,7 +2,7 @@
 
 from ._version import __version__, __version_tuple__
 
-# Register existing generators
+# Register existing views
 from .figures.dwi import (
     DwiPerShellGenerator,
     QSpaceShellsGenerator,

--- a/src/niftyone/analysis_levels/participant.py
+++ b/src/niftyone/analysis_levels/participant.py
@@ -15,7 +15,7 @@ from bids2table import BIDSTable, bids2table
 from elbow.utils import cpu_count, setup_logging
 
 from niftyone import Runner
-from niftyone.figures import generator
+from niftyone.figures import factory
 
 
 def load_config(config: Path | None) -> dict[str, Any]:
@@ -74,15 +74,15 @@ def participant(
     else:
         subs = [sub]
 
-    logging.info("Creating figure generators")
+    logging.info("Creating figure views")
     config: dict[str, Any] = load_config(config=config)
-    figure_generators = generator.create_generators(config=config)
+    figure_views = factory.create_views(config=config)
 
     runner = Runner(
         out_dir=out_dir,
         qc_dir=qc_dir,
         overwrite=overwrite,
-        figure_generators=figure_generators,
+        figure_views=figure_views,
     )
 
     _worker = partial(
@@ -142,7 +142,7 @@ def _participant_single(
 
     runner.table = index.filter("sub", sub)
     mpl.use("agg")
-    runner.gen_figures()
+    runner.create_figures()
     runner.update_metrics()
 
     logging.info(

--- a/src/niftyone/cli.py
+++ b/src/niftyone/cli.py
@@ -93,7 +93,7 @@ The different analysis levels perform the following tasks:
             default=None,
             help=(
                 "filters to apply to bids2table for figure generation - "
-                "if none provided, generate all available figures"
+                "if none provided, create all available figures"
             ),
         )
         self.participant_level.add_argument(

--- a/src/niftyone/figures/__init__.py
+++ b/src/niftyone/figures/__init__.py
@@ -1,1 +1,1 @@
-"""Initialize sub-module for generating pipeline figures."""
+"""Initialize sub-module for creating pipeline figures."""

--- a/src/niftyone/figures/dwi.py
+++ b/src/niftyone/figures/dwi.py
@@ -1,22 +1,22 @@
 """Generators associated with diffusion data."""
 
 from niclips.figures import dwi
-from niftyone.figures.generator import ViewGenerator, register
+from niftyone.figures.factory import View, register
 
 
 @register("qspace_shells")
-class QSpaceShellsGenerator(ViewGenerator):
+class QSpaceShellsGenerator(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "qspace"}}
     view_fn = staticmethod(dwi.visualize_qspace)
 
 
 @register("three_view_shell_video")
-class DwiPerShellGenerator(ViewGenerator):
+class DwiPerShellGenerator(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "bval"}}
     view_fn = staticmethod(dwi.three_view_per_shell)
 
 
 @register("signal_per_volume")
-class SignalPerVolumeGenerator(ViewGenerator):
+class SignalPerVolumeGenerator(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "signalPerVolume"}}
     view_fn = staticmethod(dwi.signal_per_volume)

--- a/src/niftyone/figures/func.py
+++ b/src/niftyone/figures/func.py
@@ -1,16 +1,16 @@
 """Generators associated with functional data."""
 
 from niclips.figures import bold
-from niftyone.figures.generator import ViewGenerator, register
+from niftyone.figures.factory import View, register
 
 
 @register("carpet_plot")
-class CarpetPlotGenerator(ViewGenerator):
+class CarpetPlotGenerator(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "carpet"}}
     view_fn = staticmethod(bold.carpet_plot)
 
 
 @register("mean_std")
-class MeanStdGenerator(ViewGenerator):
+class MeanStdGenerator(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "meanStd"}}
     view_fn = staticmethod(bold.bold_mean_std)

--- a/src/niftyone/figures/multi_view.py
+++ b/src/niftyone/figures/multi_view.py
@@ -1,22 +1,22 @@
 """Generators associated with multi-view."""
 
 from niclips.figures import multi_view
-from niftyone.figures.generator import ViewGenerator, register
+from niftyone.figures.factory import View, register
 
 
 @register("three_view")
-class ThreeViewGenerator(ViewGenerator):
+class ThreeViewGenerator(View):
     entities = {"ext": ".png", "extra_entities": {"figure": "threeView"}}
     view_fn = staticmethod(multi_view.three_view_frame)
 
 
 @register("slice_video")
-class SliceVideoGenerator(ViewGenerator):
+class SliceVideoGenerator(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "sliceVideo"}}
     view_fn = staticmethod(multi_view.slice_video)
 
 
 @register("three_view_video")
-class ThreeViewVideoGenerator(ViewGenerator):
+class ThreeViewVideoGenerator(View):
     entities = {"ext": ".mp4", "extra_entities": {"figure": "threeViewVideo"}}
     view_fn = staticmethod(multi_view.three_view_video)

--- a/src/niftyone/metrics.py
+++ b/src/niftyone/metrics.py
@@ -49,7 +49,7 @@ def _load_qc_group_metrics(qc_dir: Path, suffix: str = "T1w") -> pd.DataFrame | 
     return metrics
 
 
-def gen_niftyone_metrics_tsv(
+def create_niftyone_metrics_tsv(
     record: pd.Series,
     entities: BIDSEntities,
     out_dir: Path,
@@ -70,5 +70,5 @@ def gen_niftyone_metrics_tsv(
     # Find metrics matching image
     img_metrics = _filter_metrics_by_image(metrics=metrics, record=record)
     if len(img_metrics) > 0:
-        logging.info("Generating: %s", out_path)
+        logging.info("Creating: %s", out_path)
         img_metrics.to_csv(out_path, sep="\t", index=False)

--- a/tests/unit/niftyone/test_metrics.py
+++ b/tests/unit/niftyone/test_metrics.py
@@ -4,12 +4,12 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from bids2table import BIDSEntities, BIDSTable
 
-from niftyone.metrics import gen_niftyone_metrics_tsv
+from niftyone.metrics import create_niftyone_metrics_tsv
 
 
 @pytest.mark.b2t()
-class TestGenNiftyOneMetricsTSV:
-    def test_gen_tsv_no_metrics(
+class TestCreateNiftyOneMetricsTSV:
+    def test_create_tsv_no_metrics(
         self,
         b2t_index: BIDSTable,
         tmp_path: Path,
@@ -24,11 +24,11 @@ class TestGenNiftyOneMetricsTSV:
         ).to_path(prefix=out_dir)
         assert not out_path.exists()
 
-        gen_niftyone_metrics_tsv(
+        create_niftyone_metrics_tsv(
             record=record, entities=entities, out_dir=out_dir, qc_dir=qc_dir
         )
 
-    def test_gen_tsv_metrics(
+    def test_create_tsv_metrics(
         self,
         b2t_index: BIDSTable,
         tmp_path: Path,
@@ -44,11 +44,11 @@ class TestGenNiftyOneMetricsTSV:
         ).to_path(prefix=out_dir)
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
-        gen_niftyone_metrics_tsv(
+        create_niftyone_metrics_tsv(
             record=record, entities=entities, out_dir=out_dir, qc_dir=qc_dir
         )
 
-        assert "Generating" in caplog.text
+        assert "Creating" in caplog.text
         assert out_path.exists()
 
     def test_out_path_exists(self, b2t_index: BIDSTable, tmp_path: Path, qc_dir: Path):
@@ -63,6 +63,6 @@ class TestGenNiftyOneMetricsTSV:
         out_path.touch()
         assert out_path.exists()
 
-        gen_niftyone_metrics_tsv(
+        create_niftyone_metrics_tsv(
             record=record, entities=entities, out_dir=out_dir, qc_dir=qc_dir
         )


### PR DESCRIPTION
Large in size, but minor PR to replace the variations of the word "generator" as appropriate to avoid confusion with python generators.