### PR TITLE
Overlay patch to fix argument & color maps

### DIFF
--- a/src/niclips/figures/multi_view.py
+++ b/src/niclips/figures/multi_view.py
@@ -27,7 +27,7 @@ def multi_view_frame(
     nrows: int = 1,
     panel_height: int | None = 256,
     cmap: str = "gray",
-    overlay_cmap: list[str] = ["turbo"],
+    overlay_cmap: str | list[str] = ["turbo"],
     alpha: float = 0.5,
     fontsize: int = 14,
     **kwargs,
@@ -37,6 +37,7 @@ def multi_view_frame(
     check_iso_ras(img)
 
     overlay = [overlay] if isinstance(overlay, nib.Nifti1Image) else (overlay or [])
+    overlay_cmap = [overlay_cmap] if isinstance(overlay_cmap, str) else overlay_cmap
     if len(overlay) > 0:
         for ov in overlay:
             check_3d(ov)
@@ -96,7 +97,7 @@ def three_view_frame(
     overlay: nib.Nifti1Image | list[nib.Nifti1Image] | None = None,
     panel_height: int | None = 256,
     cmap: str = "gray",
-    overlay_cmap: list[str] = ["turbo"],
+    overlay_cmap: str | list[str] = ["turbo"],
     alpha: float = 0.5,
     fontsize: int = 14,
     **kwargs,
@@ -108,6 +109,7 @@ def three_view_frame(
     assert isinstance(img, nib.Nifti1Image)
 
     overlay = [overlay] if isinstance(overlay, nib.Nifti1Image) else (overlay or [])
+    overlay_cmap = [overlay_cmap] if isinstance(overlay_cmap, str) else overlay_cmap
     if len(overlay) > 0:
         for ov_idx, ov in enumerate(overlay):
             if ov.ndim == 4:
@@ -143,7 +145,7 @@ def three_view_video(
     overlay: nib.Nifti1Image | list[nib.Nifti1Image] | None = None,
     panel_height: int | None = 256,
     cmap: str = "gray",
-    overlay_cmap: list[str] = ["turbo"],
+    overlay_cmap: str | list[str] = ["turbo"],
     fontsize: int = 14,
     **kwargs,
 ) -> None:
@@ -151,6 +153,7 @@ def three_view_video(
     check_4d(img)
 
     overlay = [overlay] if isinstance(overlay, nib.Nifti1Image) else (overlay or [])
+    overlay_cmap = [overlay_cmap] if isinstance(overlay_cmap, str) else overlay_cmap
 
     if coord is None:
         coord = get_default_coord(img)

--- a/src/niftyone/figures/factory.py
+++ b/src/niftyone/figures/factory.py
@@ -150,6 +150,6 @@ class View(ABC, Generic[T]):
 
         if not out_path.exists() or overwrite:
             logging.info("Creating %s", out_path)
-            self.view_fn(img, out_path, overlays=overlays, **self.view_kwargs)
+            self.view_fn(img, out_path, overlay=overlays, **self.view_kwargs)
 
         plt.close("all")


### PR DESCRIPTION
A quick patch fix for overlays that fixes a couple things from the previous pr:

* `self.view_fn` argument updated from `overlays` -> `overlay`
* Revert compatability with passing overlay color maps as a string. Backwards compatability was ensured with the overlays, but not the color maps in the previous PR.