### PR TITLE
Fix width_ratios for even cols in dwi signal_per_volume

### DIFF
--- a/src/niclips/figures/dwi.py
+++ b/src/niclips/figures/dwi.py
@@ -133,10 +133,7 @@ def signal_per_volume(
 
     # Create plot
     fig = plt.figure(layout="tight", figsize=(6.4, 4.8))
-
-    aspect1 = dwi.shape[1] / dwi.shape[0]
-    aspect2 = np.max(signal) / signal.shape[-1]
-    gs = GridSpec(1, 2, figure=fig, width_ratios=[aspect1, aspect2])
+    gs = GridSpec(1, 2, figure=fig)
 
     # Plot frame over time
     ax1 = fig.add_subplot(gs[0, 0])


### PR DESCRIPTION
* Removes the `width_ratio` in parameters to let the columns be equal width (so one column isn't smaller) - was previously set dynamically by the the image size.